### PR TITLE
Fixed github actions paths

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -10,6 +10,7 @@ on:
             - assets/positivity_tally.tsv
             - .github/workflows/render_readme.yml
             - scripts/splice_readme.py
+            - DETECTION_RESULTS.tsv
 
 jobs:
     render-readme:


### PR DESCRIPTION
The last pull request we performed did not trigger our Github action in [render_readme.yml](.github/workflows/render_readme.yml). I believe this is because all of the paths involved in triggering the workflow did not change. There were no edits to the scripts in the paths, [splice_readme.py](scripts/splice_readme.py) and [render_readme.yml](.github/workflows/render_readme.yml). The [positivity_tally.tsv](assets/positivity_tally.tsv) was updated, but it was updated by another github action. I don't think that triggers this github action.

I have added [DETECTION_RESULTS.tsv](DETECTION_RESULTS.tsv) to the path so that any update of the underlying data will cause this workflow to run.