### PR TITLE
Adding a recent results section to the readme

### DIFF
--- a/.github/workflows/update_recent_tally.yml
+++ b/.github/workflows/update_recent_tally.yml
@@ -1,0 +1,103 @@
+# .github/workflows/update_recent_tally.yml
+
+name: Update recent tally
+
+on:
+    schedule: 
+        - cron: '25 6 * * 5'
+
+jobs:
+    generate-tally:
+        name: Generate recent tally
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
+
+            - name: Install Dependencies
+              run: |
+                  pip install uv
+                  uv venv
+                  source .venv/bin/activate
+                  uv pip install -r requirements.txt
+
+            - name: Tally recent cartons per state
+              run: |
+                  source .venv/bin/activate
+                  python3 scripts/positivity_tally.py \
+                  DETECTION_RESULTS.tsv \
+                  -d 90 \
+                  assets/recent_tally.tsv
+                  
+            - name: Commit recent tally
+              if: success()
+              run: |
+                  git config --global user.name 'GitHub Actions Bot'
+                  git config --global user.email 'actions@github.com'
+                  git add assets/recent_tally.tsv
+                  git fetch origin proposals
+                  git commit -m "Updating recent tally"
+                  git push --force-with-lease origin HEAD:proposals
+                  
+    render-readme:
+        name: Render new README
+        needs: generate-tally
+        runs-on: ubuntu-latest
+
+        steps:
+              - name: Checkout Code
+                uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
+
+              - name: Pull latest changes from proposals
+                run: |
+                    git fetch origin proposals
+                    git pull origin proposals
+
+              - name: Set up Python
+                uses: actions/setup-python@v4
+                with:
+                    python-version: "3.11"
+
+              - name: Install Dependencies
+                run: |
+                    pip install uv
+                    uv venv
+                    source .venv/bin/activate
+                    uv pip install -r requirements.txt
+
+              - name: Generate Markdown Table
+                run: |
+                    source .venv/bin/activate
+                    python3 scripts/tsv_to_md.py \
+                    assets/recent_tally.tsv \
+                    > assets/recent_tally.md
+      
+              - name: Splice Table into README
+                run: |
+                    source .venv/bin/activate
+                    python3 scripts/splice_recent.py
+
+              - name: Replace previous README
+                run: |
+                    rm README.md && \
+                    mv new_readme.md README.md
+      
+              - name: Commit Updated README
+                if: success()
+                run: |
+                    git config --global user.name 'GitHub Actions Bot'
+                    git config --global user.email 'actions@github.com'
+                    git add README.md
+                    git fetch origin proposals
+                    git commit -m "Updated the README file"
+                    git push --force-with-lease origin HEAD:proposals

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ MN                      |  1              |  1                 |  0             
 MO                      |  1              |  1                 |  0                 |  2024-12-17
 WI                      |  72             |  63                |  9                 |  2025-01-21
 
-## Positivity Tally by State
+## All-time Results by State
+
+Full results across the history of the project (24 April 2024-Present)
 
 Processing Plant State  |  Total Cartons  |  Negative Cartons  |  Positive Cartons  |  Latest Date Sampled
 ------------------------|-----------------|--------------------|--------------------|---------------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ To submit results of your own, read over our [proposal instructions](docs/propos
   - [Data Submission](#data-submission)
 
 ## Recent Results by State
- 
+
+Recent results in the 90 days preceding 31 January 2025
+
+Processing Plant State  |  Total Cartons  |  Negative Cartons  |  Positive Cartons  |  Latest Date Sampled
+------------------------|-----------------|--------------------|--------------------|---------------------
+CA                      |  6              |  1                 |  5                 |  2025-01-21
+CO                      |  5              |  5                 |  0                 |  2025-01-21
+IA                      |  2              |  1                 |  1                 |  2024-12-17
+IN                      |  1              |  1                 |  0                 |  2024-12-17
+MI                      |  7              |  7                 |  0                 |  2025-01-21
+MN                      |  1              |  1                 |  0                 |  2024-11-19
+MO                      |  1              |  1                 |  0                 |  2024-12-17
+WI                      |  72             |  63                |  9                 |  2025-01-21
 
 ## Positivity Tally by State
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ To submit results of your own, read over our [proposal instructions](docs/propos
     - [Naming Conventions](#naming-conventions)
   - [Data Submission](#data-submission)
 
+## Recent Results by State
+ 
+
 ## Positivity Tally by State
 
 Processing Plant State  |  Total Cartons  |  Negative Cartons  |  Positive Cartons  |  Latest Date Sampled

--- a/scripts/splice_readme.py
+++ b/scripts/splice_readme.py
@@ -57,8 +57,8 @@ def splice_readme_lines(
     """
     ignore = False
     for line in readme_lines:
-        if line.startswith("## Positivity Tally by State"):
-            new_readme.write("## Positivity Tally by State\n\n")
+        if line.startswith("## All-time Results by State"):
+            new_readme.write("## All-time Results by State\n\nFull results across the history of the project (24 April 2024-Present)\n")
             for tally_line in tally_lines:
                 new_readme.write(f"{tally_line}")
             ignore = True

--- a/scripts/splice_recent.py
+++ b/scripts/splice_recent.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+"""
+usage: splice_recent.py [-h] [-r README] [-f TALLY_FILE]
+
+Space a table from one input markdown file into the README.
+
+options:
+  -h, --help            show this help message and exit
+  -r README, --readme README
+                        The readme to be updated.
+  -f TALLY_FILE, --tally_file TALLY_FILE
+                        The file to be spliced into the readme.
+"""
+
+import argparse
+from io import TextIOWrapper
+from pathlib import Path
+from typing import List
+from datetime import datetime
+
+
+def parse_command_line_args() -> argparse.Namespace:
+    """
+    Parse a couple named arguments from the command line
+    """
+    parser = argparse.ArgumentParser(
+        description="Space a table from one input markdown file into the README.",
+    )
+    parser.add_argument(
+        "-r",
+        "--readme",
+        type=Path,
+        default=Path("README.md"),
+        required=False,
+        help="The readme to be updated.",
+    )
+    parser.add_argument(
+        "-f",
+        "--tally_file",
+        type=Path,
+        default=Path("assets/recent_tally.md"),
+        required=False,
+        help="The file to be spliced into the readme.",
+    )
+
+    return parser.parse_args()
+
+
+def splice_readme_lines(
+    readme_lines: list[str],
+    tally_lines: list[str],
+    new_readme: TextIOWrapper,
+) -> None:
+    """
+    Test a few conditions on each line to make sure the tally table is properly
+    spliced into the readme.
+    """
+    current_date = datetime.now().strftime('%d %B %Y')
+    ignore = False
+    for line in readme_lines:
+        if line.startswith("## Recent Results by State"):
+            new_readme.write(f"## Recent Results by State\n\nRecent results in the 90 days preceding {current_date}\n\n")
+            for tally_line in tally_lines:
+                new_readme.write(f"{tally_line}")
+            ignore = True
+
+        if line.startswith("## Positivity Tally by State"):
+            new_readme.write("\n")
+            ignore = False
+
+        if not ignore:
+            new_readme.write(f"{line}")
+            continue
+
+
+def main() -> None:
+    """
+    Script entrypoint
+    """
+
+    # parse out command line args
+    args = parse_command_line_args()
+
+    # open the input readme and tally md file and collect the lines from each
+    with open(args.readme, encoding="utf8") as readme_handle:
+        readme_lines = list(readme_handle.readlines())
+    with open(args.tally_file, encoding="utf8") as tally_handle:
+        tally_lines = list(tally_handle.readlines())
+
+    # open the new readme and handle splicing the table into the new readme
+    with open("new_readme.md", "w", encoding="utf8") as new_readme:
+        splice_readme_lines(readme_lines, tally_lines, new_readme)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This addresses #49.

The main changes:
- Introduced a new section into the README.md, which summarizes what we've tested in the past 90 days
- Added an optional argument to positivity_tally.py to allow the table to be time-filtered a certain number of days into the past
- Added a script to actually do the splicing into the README
- Wrote a new github action that is scheduled to run every Saturday to update the README